### PR TITLE
Add the `findOneFromPublication()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ To get the documents published by a given named publication in a given collectio
 ``` js
 Collection.findFromPublication(name, query, options);
 ```
+or
+``` js
+Collection.findOneFromPublication(name, query, options);
+```
 
 #### Example
 
@@ -38,6 +42,7 @@ if (Meteor.isClient) {
   
   // in a helper, etc
   var postsCursor = Posts.findFromPublication('allPosts');
+  var randomPost = Posts.findOneFromPublication('allPosts');  
 }
 ```
 

--- a/find-from-publication.js
+++ b/find-from-publication.js
@@ -55,4 +55,16 @@ if (Meteor.isServer) {
     
     return this.find(where, options);
   };
+
+  Meteor.Collection.prototype.findOneFromPublication = function(name, where, options) {
+    var ids = SubscriptionMetadata.find({
+      collectionName: this._name,
+      publicationName: name
+    }, {sort: {rank: -1}}).map(function(doc) {
+      return doc.documentId;
+    });
+    where = _.extend({_id: {$in: ids}}, where);
+
+    return this.findOne(where, options);
+  };
 }


### PR DESCRIPTION
On the client side, we have `Collection.findFromPublication()`,
mimicking the behavior of `Collection.find()`, just limined to a publication.

Analogously, this PR adds `collection.findOneFromPublication()`,
mimicking the behavior of `collection.findOne()`.
